### PR TITLE
Fix functions using String type for Password Parameters

### DIFF
--- a/PowervRA/Functions/Public/Connect-vRAServer.ps1
+++ b/PowervRA/Functions/Public/Connect-vRAServer.ps1
@@ -26,6 +26,7 @@
 
     .INPUTS
     System.String
+    System.SecureString
     Management.Automation.PSCredential
     Switch
 
@@ -33,10 +34,11 @@
     System.Management.Automation.PSObject.
 
     .EXAMPLE
-    Connect-vRAServer -Server vraappliance01.domain.local -Tenant Tenant01 -Username TenantAdmin01 -Password P@ssword -IgnoreCertRequirements
+    Connect-vRAServer -Server vraappliance01.domain.local -Tenant Tenant01 -Credential (Get-Credential)
 
     .EXAMPLE
-    Connect-vRAServer -Server vraappliance01.domain.local -Tenant Tenant01 -Credential (Get-Credential)
+    $SecurePassword = ConvertTo-SecureString “P@ssword” -AsPlainText -Force
+    Connect-vRAServer -Server vraappliance01.domain.local -Tenant Tenant01 -Username TenantAdmin01 -Password $SecurePassword -IgnoreCertRequirements
 #>
 [CmdletBinding(DefaultParametersetName="Username")][OutputType('System.Management.Automation.PSObject')]
 
@@ -56,7 +58,7 @@
 
         [parameter(Mandatory=$true,ParameterSetName="Username")]
         [ValidateNotNullOrEmpty()]
-        [String]$Password,
+        [SecureString]$Password,
 
         [Parameter(Mandatory=$true,ParameterSetName="Credential")]
         [ValidateNotNullOrEmpty()]
@@ -96,10 +98,16 @@
 
     }
 
+    # --- Convert Secure Credentials to a format for sending in the JSON payload
     if ($PSBoundParameters.ContainsKey("Credential")){
 
         $Username = $Credential.UserName
-        $Password = $Credential.GetNetworkCredential().Password
+        $JSONPassword = $Credential.GetNetworkCredential().Password
+    }
+
+    if ($PSBoundParameters.ContainsKey("Password")){
+
+        $JSONPassword = (New-Object System.Management.Automation.PSCredential (“username”, $Password)).GetNetworkCredential().Password
     }
 
     try {
@@ -108,7 +116,7 @@
         $JSON = @"
         {
             "username":"$($Username)",
-            "password":"$($Password)",
+            "password":"$($JSONPassword)",
             "tenant":"$($Tenant)"
         }
 "@

--- a/PowervRA/Functions/Public/Connect-vRAServer.ps1
+++ b/PowervRA/Functions/Public/Connect-vRAServer.ps1
@@ -107,7 +107,7 @@
 
     if ($PSBoundParameters.ContainsKey("Password")){
 
-        $JSONPassword = (New-Object System.Management.Automation.PSCredential (“username”, $Password)).GetNetworkCredential().Password
+        $JSONPassword = (New-Object System.Management.Automation.PSCredential(“username”, $Password)).GetNetworkCredential().Password
     }
 
     try {

--- a/PowervRA/Functions/Public/identity/New-vRATenantDirectory.ps1
+++ b/PowervRA/Functions/Public/identity/New-vRATenantDirectory.ps1
@@ -191,11 +191,11 @@
 
         if ($PSBoundParameters.ContainsKey("Password")){
 
-            $JSONPassword = (New-Object System.Management.Automation.PSCredential (“username”, $Password)).GetNetworkCredential().Password
+            $JSONPassword = (New-Object System.Management.Automation.PSCredential(“username”, $Password)).GetNetworkCredential().Password
         }
         if ($PSBoundParameters.ContainsKey("DomainAdminPassword")){
 
-            $JSONDomainAdminPassword = (New-Object System.Management.Automation.PSCredential (“username”, $DomainAdminPassword)).GetNetworkCredential().Password
+            $JSONDomainAdminPassword = (New-Object System.Management.Automation.PSCredential(“username”, $DomainAdminPassword)).GetNetworkCredential().Password
         }
         if ($PSBoundParameters.ContainsKey("GroupBaseSearchDNs")){
 

--- a/PowervRA/Functions/Public/identity/New-vRATenantDirectory.ps1
+++ b/PowervRA/Functions/Public/identity/New-vRATenantDirectory.ps1
@@ -67,14 +67,16 @@
     Body text to send in JSON format
 
     .INPUTS
-    System.String.
+    System.String
+    System.SecureString
 
     .OUTPUTS
     System.Management.Automation.PSObject
 
     .EXAMPLE
+    $SecurePassword = ConvertTo-SecureString “P@ssword” -AsPlainText -Force
     New-vRATenantDirectory -ID Tenant01 -Name Tenant01 -Description "This is the Tenant01 Directory" -Type AD -Domain "vrademo.local" -UserNameDN "CN=vrasvc,OU=Service Accounts,OU=HQ,DC=vrademo,DC=local" `
-      -Password "P@ssw0rd" -URL "ldap://dc01.vrademo.local:389" -GroupBaseSearchDN "OU=Tenant01,OU=Tenants,DC=vrademo,DC=local" -UserBaseSearchDN "OU=Tenant01,OU=Tenants,DC=vrademo,DC=local" `
+      -Password $SecurePassword -URL "ldap://dc01.vrademo.local:389" -GroupBaseSearchDN "OU=Tenant01,OU=Tenants,DC=vrademo,DC=local" -UserBaseSearchDN "OU=Tenant01,OU=Tenants,DC=vrademo,DC=local" `
      -GroupBaseSearchDNs "OU=Tenant01,OU=Tenants,DC=vrademo,DC=local" -UserBaseSearchDNs "OU=Tenant01,OU=Tenants,DC=vrademo,DC=local" -TrustAll
     
     .EXAMPLE
@@ -136,7 +138,7 @@
 
     [parameter(Mandatory=$true,ParameterSetName="Standard")]
     [ValidateNotNullOrEmpty()]
-    [String]$Password,
+    [SecureString]$Password,
 
     [parameter(Mandatory=$true,ParameterSetName="Standard")]
     [ValidateNotNullOrEmpty()]
@@ -168,7 +170,7 @@
 
     [parameter(Mandatory=$false,ParameterSetName="Standard")]
     [ValidateNotNullOrEmpty()]
-    [String]$DomainAdminPassword,
+    [SecureString]$DomainAdminPassword,
 
     [parameter(Mandatory=$false,ParameterSetName="Standard")]
     [ValidateNotNullOrEmpty()]
@@ -186,7 +188,15 @@
     )    
 
     begin {
-    
+
+        if ($PSBoundParameters.ContainsKey("Password")){
+
+            $JSONPassword = (New-Object System.Management.Automation.PSCredential (“username”, $Password)).GetNetworkCredential().Password
+        }
+        if ($PSBoundParameters.ContainsKey("DomainAdminPassword")){
+
+            $JSONDomainAdminPassword = (New-Object System.Management.Automation.PSCredential (“username”, $DomainAdminPassword)).GetNetworkCredential().Password
+        }
         if ($PSBoundParameters.ContainsKey("GroupBaseSearchDNs")){
 
             if ($GroupBaseSearchDNs.Count -gt 1){
@@ -255,12 +265,12 @@
                   "type" : "$($Type)",
                   "userNameDn" : "$($UserNameDN)",
                   "groupBaseSearchDn" : "$($GroupBaseSearchDN)",
-                  "password" : "$($Password)",
+                  "password" : "$($JSONPassword)",
                   "url" : "$($URL)",
                   "userBaseSearchDn" : "$($UserBaseSearchDN)",
                   "domain" : "$($Domain)",
                   "domainAdminUsername" : "$($DomainAdminUsername)",
-                  "domainAdminPassword" : "$($DomainAdminPassword)",
+                  "domainAdminPassword" : "$($JSONDomainAdminPassword)",
                   "subdomains" : [ "$($Subdomains)" ],
                   "groupBaseSearchDns" : [ $($GroupBaseSearchDNs) ],
                   "userBaseSearchDns" : [ $($UserBaseSearchDNs) ],

--- a/PowervRA/Functions/Public/identity/Set-vRATenantDirectory.ps1
+++ b/PowervRA/Functions/Public/identity/Set-vRATenantDirectory.ps1
@@ -188,11 +188,11 @@
 
         if ($PSBoundParameters.ContainsKey("Password")){
 
-            $JSONPassword = (New-Object System.Management.Automation.PSCredential (“username”, $Password)).GetNetworkCredential().Password
+            $JSONPassword = (New-Object System.Management.Automation.PSCredential(“username”, $Password)).GetNetworkCredential().Password
         }
         if ($PSBoundParameters.ContainsKey("DomainAdminPassword")){
 
-            $JSONDomainAdminPassword = (New-Object System.Management.Automation.PSCredential (“username”, $DomainAdminPassword)).GetNetworkCredential().Password
+            $JSONDomainAdminPassword = (New-Object System.Management.Automation.PSCredential(“username”, $DomainAdminPassword)).GetNetworkCredential().Password
         }
         if ($PSBoundParameters.ContainsKey("GroupBaseSearchDNs")){
 

--- a/tests/Test001-Connection.Tests.ps1
+++ b/tests/Test001-Connection.Tests.ps1
@@ -13,7 +13,8 @@ Describe -Name 'Connectivity Tests' -Fixture {
 
     It -Name 'Connects to a vRA Appliance and generates a token' -Test {
 
-        Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+        $ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password -AsPlainText -Force
+        Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
         $($Global:vRAConnection.Token) | Should Be $true
     }
 

--- a/tests/Test002-Tenant.Tests.ps1
+++ b/tests/Test002-Tenant.Tests.ps1
@@ -22,7 +22,8 @@ Describe -Name 'Tenant Tests' -Fixture {
 
     It -Name "Create named Tenant Directory $($JSON.TenantDirectory.Name)" -Test {
 
-        $TenantDirectoryA = New-vRATenantDirectory -ID $JSON.TenantDirectory.ID -Name $JSON.TenantDirectory.Name -Description $JSON.TenantDirectory.Description -Type $JSON.TenantDirectory.Type -Domain $JSON.TenantDirectory.Domain -UserNameDN $JSON.TenantDirectory.UserNameDN -Password $JSON.TenantDirectory.Password -URL $JSON.TenantDirectory.URL -GroupBaseSearchDN $JSON.TenantDirectory.GroupBaseSearchDN -UserBaseSearchDN $JSON.TenantDirectory.UserBaseSearchDN -GroupBaseSearchDNs $JSON.TenantDirectory.GroupBaseSearchDNs -UserBaseSearchDNs $JSON.TenantDirectory.UserBaseSearchDNs -TrustAll
+        $SecurePassword = ConvertTo-SecureString $JSON.TenantDirectory.Password -AsPlainText -Force
+        $TenantDirectoryA = New-vRATenantDirectory -ID $JSON.TenantDirectory.ID -Name $JSON.TenantDirectory.Name -Description $JSON.TenantDirectory.Description -Type $JSON.TenantDirectory.Type -Domain $JSON.TenantDirectory.Domain -UserNameDN $JSON.TenantDirectory.UserNameDN -Password $SecurePassword -URL $JSON.TenantDirectory.URL -GroupBaseSearchDN $JSON.TenantDirectory.GroupBaseSearchDN -UserBaseSearchDN $JSON.TenantDirectory.UserBaseSearchDN -GroupBaseSearchDNs $JSON.TenantDirectory.GroupBaseSearchDNs -UserBaseSearchDNs $JSON.TenantDirectory.UserBaseSearchDNs -TrustAll
         $TenantDirectoryA.Name | Should Be $JSON.TenantDirectory.Name
     }
 

--- a/tests/Test002-Tenant.Tests.ps1
+++ b/tests/Test002-Tenant.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.DefaultTenantConnection.vRAAppliance -Tenant $JSON.DefaultTenantConnection.Tenant -Username $JSON.DefaultTenantConnection.Username -Password $JSON.DefaultTenantConnection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.DefaultTenantConnection.Password -AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.DefaultTenantConnection.vRAAppliance -Tenant $JSON.DefaultTenantConnection.Tenant -Username $JSON.DefaultTenantConnection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Tenant Tests' -Fixture {

--- a/tests/Test003-ReservationPolicy.Tests.ps1
+++ b/tests/Test003-ReservationPolicy.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Reservation Policy Tests' -Fixture {

--- a/tests/Test004-BusinessGroup.Tests.ps1
+++ b/tests/Test004-BusinessGroup.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Business Group Tests' -Fixture {

--- a/tests/Test005-Catalog-Service.Tests.ps1
+++ b/tests/Test005-Catalog-Service.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Catalog-Service Tests' -Fixture {

--- a/tests/Test006-BlueprintAndServiceBlueprint.Tests.ps1
+++ b/tests/Test006-BlueprintAndServiceBlueprint.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Blueprint Tests' -Fixture {

--- a/tests/Test007-Content-Management-Service.Tests.ps1
+++ b/tests/Test007-Content-Management-Service.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Content-Management-Service Tests' -Fixture {

--- a/tests/Test008-Reservation.Tests.ps1
+++ b/tests/Test008-Reservation.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Reservation Tests' -Fixture {

--- a/tests/Test009-Principal.Tests.ps1
+++ b/tests/Test009-Principal.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'User Principal Tests' -Fixture {

--- a/tests/Test010-IaaS-Proxy-Provider.Tests.ps1
+++ b/tests/Test010-IaaS-Proxy-Provider.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Iaas-Proxy-Provider Tests' -Fixture {

--- a/tests/Test099-Misc.Tests.ps1
+++ b/tests/Test099-Misc.Tests.ps1
@@ -2,7 +2,8 @@
 $JSON = Get-Content .\Variables.json -Raw | ConvertFrom-JSON
 
 # --- Startup
-$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $JSON.Connection.Password -IgnoreCertRequirements
+$ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password-AsPlainText -Force
+$Connection = Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Tenant $JSON.Connection.Tenant -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
 
 # --- Tests
 Describe -Name 'Misc Tests' -Fixture {


### PR DESCRIPTION
Updated these functions to use SecureString instead of String for Password Parameters.

Connect-vRAServer
New-vRATenantDirectory
Set-vRATenantDirectory

To fix issue #105 