### PR TITLE
New cmdlet Import-vRAContentData

### DIFF
--- a/src/Functions/Public/content-management-service/Import-vRAContentData.ps1
+++ b/src/Functions/Public/content-management-service/Import-vRAContentData.ps1
@@ -1,0 +1,79 @@
+﻿function Import-vRAContentData {
+<#
+    .SYNOPSIS
+    Import a yaml file associated with vRA content
+
+    .DESCRIPTION
+    Import a yaml file associated with vRA content
+
+    .PARAMETER ContentType
+    The Content Type of the imported item such as composite-blueprint or property-group
+
+    .PARAMETER Path
+    The path to file to import
+
+    .INPUTS
+    System.String
+
+    .OUTPUTS
+    System.String
+
+    .EXAMPLE
+    Import-vRAContentData -Path ./CentOS.yaml -ContentType Composite-Blueprint
+
+#>
+[CmdletBinding(SupportsShouldProcess,ConfirmImpact="High")][OutputType('System.String')]
+
+    Param (
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [ValidateSet("form-definition","property-group", "property-definition", "composite-blueprint", "component-profile-value", "software-component", "o11n-package-type", "reservation-type-category-type", "reservation-type-type", "xaas-bundle-content", "xaas-blueprint", "xaas-resource-action", "xaas-resource-type", "xaas-resource-mapping")]
+        [String]$ContentType,
+
+        [Parameter(Mandatory=$true)]
+        [ValidateNotNullOrEmpty()]
+        [String]$Path
+    )
+
+    Begin {
+
+        xRequires -Version 7.0
+
+        $Headers = @{
+
+            "Authorization" = "Bearer $($Global:vRAConnection.Token)";
+            "Accept" = "Application/json"
+            "Content-Type" = "text/yaml"
+        }
+    }
+
+    Process {
+
+        try {
+
+            if ($PSCmdlet.ShouldProcess($ContentId)){
+
+                $Body = Get-Cotent -Raw -Path $Path
+
+                #vRA API - The string "import" isn't actually processed by vRA. The content id is processed via the body automatically. Validated this for new and exiting content items.
+                $URI = "/content-management-service/api/contents/$($ContentType)/import/data"
+
+                Invoke-vRARestMethod -Method POST -URI $URI -Headers $Headers -Verbose:$VerbosePreference -Body $Body
+
+            }
+
+        }
+        catch [Exception]{
+
+            throw
+
+        }
+
+    }
+
+    End {
+
+    }
+
+}

--- a/src/Functions/Public/content-management-service/Import-vRAContentData.ps1
+++ b/src/Functions/Public/content-management-service/Import-vRAContentData.ps1
@@ -19,7 +19,7 @@
     System.String
 
     .EXAMPLE
-    Import-vRAContentData -Path ./CentOS.yaml -ContentType Composite-Blueprint
+    Import-vRAContentData -Path ./CentOS.yaml -ContentType composite-blueprint
 
 #>
 [CmdletBinding(SupportsShouldProcess,ConfirmImpact="High")][OutputType('System.String')]

--- a/src/Functions/Public/content-management-service/Import-vRAContentData.ps1
+++ b/src/Functions/Public/content-management-service/Import-vRAContentData.ps1
@@ -52,9 +52,9 @@
 
         try {
 
-            if ($PSCmdlet.ShouldProcess($ContentId)){
+            if ($PSCmdlet.ShouldProcess($Path)){
 
-                $Body = Get-Cotent -Raw -Path $Path
+                $Body = Get-Content -Raw -Path $Path
 
                 #vRA API - The string "import" isn't actually processed by vRA. The content id is processed via the body automatically. Validated this for new and exiting content items.
                 $URI = "/content-management-service/api/contents/$($ContentType)/import/data"

--- a/tests/Test007-Content-Management-Service.Tests.ps1
+++ b/tests/Test007-Content-Management-Service.Tests.ps1
@@ -63,6 +63,14 @@ Describe -Name 'Content-Management-Service Tests' -Fixture {
 
         }
 
+        It -Name "Import Content Item" -Test {
+
+          $TestYamlImport = Import-vRAContentData -ContentType "composite-blueprint" -Path .\CentOS.yaml
+          $TestYamlStatus = $TestYamlImport.operationStatus
+          (($TestYamlStatus -contains "SUCCESS") -or ($TestYamlStatus -contains "WARNING")) | Should Be $true
+
+        }
+
     }
 
     Context -Name "Package" -Fixture {
@@ -93,9 +101,9 @@ Describe -Name 'Content-Management-Service Tests' -Fixture {
         It -Name "Remove named Package" -Test {
 
             Remove-vRAPackage -Name $PackageName -Confirm:$false
-            
+
             try {
-            
+
                 $Package = Get-vRAPackage -Name $PackageName
             }
             catch [Exception]{

--- a/tests/data/CentOS.yaml
+++ b/tests/data/CentOS.yaml
@@ -1,0 +1,56 @@
+id: CentOS
+name: CentOS
+description: Example Blueprint
+status: PUBLISHED
+components:
+  vSphere__vCenter__Machine_1:
+    type: Infrastructure.CatalogItem.Machine.Virtual.vSphere
+    data:
+      _cluster:
+        default: 1
+        max: 1
+        min: 1
+      action:
+        fixed: Create
+      allow_storage_policies:
+        fixed: false
+      blueprint_type:
+        fixed: '1'
+      cpu:
+        default: 1
+        max: 4
+        min: 1
+      disks:
+      - capacity: 100
+        id: 1549642413626
+        initial_location: ''
+        is_clone: false
+        label: ''
+        storage_reservation_policy: ''
+        userCreated: true
+        volumeId: 0
+      max_network_adapters: {}
+      max_volumes: {}
+      memory:
+        default: 4096
+        max: 4096
+        min: 4096
+      nics:
+      - address: ''
+        assignment_type: Static
+        id: 0
+        load_balancing: ''
+        network: null
+        network_profile: null
+      provisioning_workflow:
+        fixed:
+          id: BasicVmWorkflow
+          label: BasicVmWorkflow
+      security_groups: []
+      security_tags: []
+      storage:
+        default: 100
+        max: 100
+        min: 100
+layout:
+  vSphere__vCenter__Machine_1: 0,0


### PR DESCRIPTION
New cmdlet to import a yaml file. Validated for update and create of a blueprint. Test also written with a basic blueprint yaml file for import. 