### PR TITLE
Secure vRAConnection variable from casual inspection

### DIFF
--- a/docs/functions/Get-vRABusinessGroup.md
+++ b/docs/functions/Get-vRABusinessGroup.md
@@ -36,7 +36,7 @@ Aliases:
 
 Required: False
 Position: 1
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/Get-vRAGroupPrincipal.md
+++ b/docs/functions/Get-vRAGroupPrincipal.md
@@ -62,7 +62,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/Get-vRAUserPrincipal.md
+++ b/docs/functions/Get-vRAUserPrincipal.md
@@ -72,7 +72,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/Get-vRAUserPrincipalGroupMembership.md
+++ b/docs/functions/Get-vRAUserPrincipalGroupMembership.md
@@ -62,7 +62,7 @@ Aliases:
 
 Required: False
 Position: 2
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/New-vRABusinessGroup.md
+++ b/docs/functions/New-vRABusinessGroup.md
@@ -113,7 +113,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/New-vRAGroupPrincipal.md
+++ b/docs/functions/New-vRAGroupPrincipal.md
@@ -57,7 +57,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/New-vRAPropertyDefinition.md
+++ b/docs/functions/New-vRAPropertyDefinition.md
@@ -136,7 +136,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/New-vRAReservation.md
+++ b/docs/functions/New-vRAReservation.md
@@ -148,7 +148,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/New-vRAUserPrincipal.md
+++ b/docs/functions/New-vRAUserPrincipal.md
@@ -91,7 +91,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/Remove-vRAGroupPrincipal.md
+++ b/docs/functions/Remove-vRAGroupPrincipal.md
@@ -51,7 +51,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/Remove-vRAUserPrincipal.md
+++ b/docs/functions/Remove-vRAUserPrincipal.md
@@ -51,7 +51,7 @@ Aliases:
 
 Required: False
 Position: 2
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/functions/Set-vRAUserPrincipal.md
+++ b/docs/functions/Set-vRAUserPrincipal.md
@@ -65,7 +65,7 @@ Aliases:
 
 Required: False
 Position: 2
-Default value: $Global:vRAConnection.Tenant
+Default value: $Script:vRAConnection.Tenant
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/src/Functions/Private/xRequires.ps1
+++ b/src/Functions/Private/xRequires.ps1
@@ -42,17 +42,17 @@ function xRequires {
     )
 
     # --- Test for vRA API version
-    if (-not $Global:vRAConnection){
+    if (-not $Script:vRAConnection){
         throw "vRA Connection variable does not exist. Please run Connect-vRAServer first to create it"
     }
 
     # --- Convert version strings to [version] objects
-    $APIVersion = [version]$Global:vRAConnection.APIVersion
+    $APIVersion = [version]$Script:vRAConnection.APIVersion
     $RequiredVersion = [version]$Version
 
     if ($APIVersion -lt $RequiredVersion) {
         $PSCallStack = Get-PSCallStack
-        Write-Error -Message "$($PSCallStack[1].Command) is not supported with vRA API version $($Global:vRAConnection.APIVersion)"
+        Write-Error -Message "$($PSCallStack[1].Command) is not supported with vRA API version $($Script:vRAConnection.APIVersion)"
         break
     }
 }

--- a/src/Functions/Public/Connect-vRAServer.ps1
+++ b/src/Functions/Public/Connect-vRAServer.ps1
@@ -221,7 +221,7 @@
             }
 
             # --- Create Output Object
-            $Global:vRAConnection = [PSCustomObject] @{
+            $Script:vRAConnection = [PSCustomObject] @{
 
                 Server = "https://$($Server)"
                 Token = $token
@@ -232,7 +232,7 @@
             }
 
             # --- Update vRAConnection with API version
-            $Global:vRAConnection.APIVersion = (Get-vRAAPIVersion).APIVersion
+            $Script:vRAConnection.APIVersion = (Get-vRAAPIVersion).APIVersion
 
         }
         catch [Exception]{

--- a/src/Functions/Public/Disconnect-vRAServer.ps1
+++ b/src/Functions/Public/Disconnect-vRAServer.ps1
@@ -17,21 +17,21 @@
     Param ()
 
     # --- Test for existing connection to vRA
-    if (-not $Global:vRAConnection){
+    if (-not $Script:vRAConnection){
 
         throw "vRA Connection variable does not exist. Please run Connect-vRAServer first to create it"
     }
 
-    if ($PSCmdlet.ShouldProcess($Global:vRAConnection.Server)){
+    if ($PSCmdlet.ShouldProcess($Script:vRAConnection.Server)){
 
         try {
 
             # --- Remove custom Security Protocol if it has been specified
-            if ($Global:vRAConnection.SslProtocol -ne 'Default'){
+            if ($Script:vRAConnection.SslProtocol -ne 'Default'){
 
                 if (!$IsCoreCLR) {
 
-                    [System.Net.ServicePointManager]::SecurityProtocol -= [System.Net.SecurityProtocolType]::$($Global:vRAConnection.SslProtocol)
+                    [System.Net.ServicePointManager]::SecurityProtocol -= [System.Net.SecurityProtocolType]::$($Script:vRAConnection.SslProtocol)
                 }
             }
 

--- a/src/Functions/Public/Invoke-vRARestMethod.ps1
+++ b/src/Functions/Public/Invoke-vRARestMethod.ps1
@@ -83,13 +83,13 @@
     )
 
     # --- Test for existing connection to vRA
-    if (-not $Global:vRAConnection){
+    if (-not $Script:vRAConnection){
 
         throw "vRA Connection variable does not exist. Please run Connect-vRAServer first to create it"
     }
 
     # --- Create Invoke-RestMethod Parameters
-    $FullURI = "$($Global:vRAConnection.Server)$($URI)"
+    $FullURI = "$($Script:vRAConnection.Server)$($URI)"
 
     # --- Add default headers if not passed
     if (!$PSBoundParameters.ContainsKey("Headers")){
@@ -98,7 +98,7 @@
 
             "Accept"="application/json";
             "Content-Type" = "application/json";
-            "Authorization" = "Bearer $($Global:vRAConnection.Token)";
+            "Authorization" = "Bearer $($Script:vRAConnection.Token)";
         }
     }
 
@@ -124,15 +124,15 @@
     }
 
     # --- Support for PowerShell Core certificate checking
-    if (!($Global:vRAConnection.SignedCertificates) -and ($IsCoreCLR)) {
+    if (!($Script:vRAConnection.SignedCertificates) -and ($IsCoreCLR)) {
 
         $Params.Add("SkipCertificateCheck", $true);
     }
 
     # --- Support for PowerShell Core SSL protocol checking
-    if (($Global:vRAConnection.SslProtocol -ne 'Default') -and ($IsCoreCLR)) {
+    if (($Script:vRAConnection.SslProtocol -ne 'Default') -and ($IsCoreCLR)) {
 
-        $Params.Add("SslProtocol", $Global:vRAConnection.SslProtocol);
+        $Params.Add("SslProtocol", $Script:vRAConnection.SslProtocol);
     }
 
     try {

--- a/tests/Test001-Connection.Tests.ps1
+++ b/tests/Test001-Connection.Tests.ps1
@@ -15,13 +15,13 @@ Describe -Name 'Connectivity Tests' -Fixture {
 
         $ConnectionPassword = ConvertTo-SecureString $JSON.Connection.Password -AsPlainText -Force
         Connect-vRAServer -Server $JSON.Connection.vRAAppliance -Username $JSON.Connection.Username -Password $ConnectionPassword -IgnoreCertRequirements
-        $($Global:vRAConnection.Token) | Should Be $true
+        $($Script:vRAConnection.Token) | Should Be $true
     }
 
     It -Name 'Connects to a vRA Appliance with a refresh_token and retrieves the access token' -Test {
 
         Connect-vRAServer -Server $JSON.Connection.vRAAppliance -APIToken $JSON.Connection.Refresh_Token -IgnoreCertRequirements
-        $($Global:vRAConnection.Token) | Should Be $true
+        $($Script:vRAConnection.Token) | Should Be $true
 
     }
 
@@ -32,6 +32,6 @@ Describe -Name 'Disconnectivity Tests' -Fixture {
     It -Name 'Disconnects from a vRA Appliance' -Test {
 
         Disconnect-vRAServer -Confirm:$false
-        $($Global:vRAConnection.Token) | Should Be $null
+        $($Script:vRAConnection.Token) | Should Be $null
     }
 }

--- a/tests/Test010-IaaS-Proxy-Provider.Tests.ps1
+++ b/tests/Test010-IaaS-Proxy-Provider.Tests.ps1
@@ -10,7 +10,7 @@ Describe -Name 'Iaas-Proxy-Provider Tests' -Fixture {
 
     Context -Name 'Network Profile' -Fixture {
 
-        $APIVersion = [version]$Global:vRAConnection.APIVersion
+        $APIVersion = [version]$Script:vRAConnection.APIVersion
         $RequiredVersion = [version]"7.1"
 
         if ($APIVersion -lt $RequiredVersion) {


### PR DESCRIPTION
Switch from Global scope to Script scope, which protects the tokens from casual inspection. Still outputting the data in Connect-vRAServer as it can be important for automation.  This addresses issue #227 

** NOTE: for anyone using $Gobal:vRAConnection outside of the module, this would be a breaking change.  You will need to capture the output from Connect-vRAServer instead.