### PR TITLE
Add pagination support to Invoke-vRAMethod

### DIFF
--- a/src/Functions/Public/Disconnect-vRAServer.ps1
+++ b/src/Functions/Public/Disconnect-vRAServer.ps1
@@ -44,7 +44,7 @@
         finally {
 
             Write-Verbose -Message "Removing vRAConnection global variable"
-            Remove-Variable -Name vRAConnection -Scope Global -Force -ErrorAction SilentlyContinue
+            Remove-Variable -Name vRAConnection -Scope Script -Force -ErrorAction SilentlyContinue
         }
     }
 }

--- a/src/Functions/Public/Invoke-vRARestMethod.ps1
+++ b/src/Functions/Public/Invoke-vRARestMethod.ps1
@@ -143,8 +143,36 @@
             Invoke-WebRequest @Params
         }
         else {
+            $Page = 1
+            Do {
+                $Result = Invoke-RestMethod @Params
+                Write-Output $Result
 
-            Invoke-RestMethod @Params
+                # Check if endpoint supports pagination
+                $Properties = $Result | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+                If ($Properties -contains "last")
+                {
+                    If (-not $Result.last)
+                    {
+                        $Page ++
+                        # Check if parameter is already specified in Uri
+                        $AddParam = "?"
+                        If ($FullURI -match "\?")
+                        {
+                            $AddParam = "&"
+                        }
+                        $Params.Uri = "$($FullURI)$($AddParam)page=$Page"
+                    }
+                    Else
+                    {
+                        $Escape = $true
+                    }
+                }
+                Else
+                {
+                    $Escape = $true
+                }
+            } Until ($Escape)
         }
     }
     catch {


### PR DESCRIPTION
* Fixed scope bug in Disconnect-vRAServer. 
* Added Pagination support for Invoke-vRAMethod

BEFORE MERGING: my vRA implementation is so new none of my API endpoints have more then the limit so I don't have any multiple pages.  Hopefully someone with a much bigger system could test?

Example:
`$Splat = @{
    Method = "get"
    URI    = "/deployment/api/deployments" 
}
Invoke-vRARestMethod @Splat`

