### PR TITLE
Bugfix update connect vraserver function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 tests/*.json
 Release/
 .DS_Store
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "gitdoc.enabled": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "gitdoc.enabled": false
-}

--- a/src/Functions/Public/Connect-vRAServer.ps1
+++ b/src/Functions/Public/Connect-vRAServer.ps1
@@ -192,7 +192,7 @@
                         "Accept"="application/json";
                         "Content-Type" = "application/json";
                     }
-                    Body = ($RawBody | ConvertTo-Json)
+                    Body = $RawBody | ConvertTo-Json
 
                 }
 
@@ -213,9 +213,9 @@
                 try {
                     $Response = Invoke-RestMethod @Params
                 } catch [System.Net.WebException]{
-                    if ($_.Exception.Response.StatusCode -eq "BadRequest" -and $null -ne $AlternateJson) {
+                    if ($_.Exception.Response.StatusCode -eq "BadRequest") {
                         $RawBody.username = $Username
-                        $Params.Body = ($RawBody | ConvertTo-Json)
+                        $Params.Body = $RawBody | ConvertTo-Json
                         $Response = Invoke-RestMethod @Params
                     } else {
                         throw $_


### PR DESCRIPTION
I have a new update to the connect commandlet. I have removed the need for -UserAttribute, simply by handling a 400 error and trying a second time by tacking that @Domain portion of the username back on. This makes this issue transparent to the user.

I have also added a step where after using the CSP login endpoint, I then pass its refresh token to the IaaS Login API (documented in 8.3 release notes as the desired process). This is all tested against 8.2 and 8.3 versions of vRA.