### PR TITLE
Allow username to be an email address

### DIFF
--- a/src/Functions/Public/Connect-vRAServer.ps1
+++ b/src/Functions/Public/Connect-vRAServer.ps1
@@ -166,11 +166,16 @@
                     if ($Username -match '@') {
                         # Log in using the advanced authentication API
                         $User = $Username.split('@')[0]
-                        $Domain = $Username.split('@')[1]
+                        
+                        if ($Username -like "*@*@*") {
+                            # If the username contains 2x @, the first part is probably an email address.
+                            $User = $User + $Username.split('@')[1]
+                        }
+
                         $RawBody = @{
                             username = $User
                             password = $JSONPassword
-                            domain = $Domain
+                            domain = $Username.split('@')[-1]
                         }
                     } else {
                         # -- Login with the basic authentication API


### PR DESCRIPTION
We login to vRA using our email addresses. The domain in the email address is not the same as the domain we need to use to login. By looking at 2x @ in the username, we can assume the first part is an email address. This way, 'email@address.com@domain.local' could be used to login.